### PR TITLE
docs: var/uvar are really variance, not standard deviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 
 * clip: Clip to process. Any planar format with either integer sample type of 8-16 bit depth or float sample type of 32 bit depth is supported.
 
-* var, uvar: The standard deviation (strength) of the luma and chroma noise, 0 is disabled. `uvar` does nothing for GRAY and RGB formats.
+* var, uvar: The variance (strength) of the luma and chroma noise, 0 is disabled. `uvar` does nothing for GRAY and RGB formats.
 
 * hcorr, vcorr: Horizontal and vertical correlation, which causes a nifty streaking effect. Range 0.0-1.0
 


### PR DESCRIPTION
Perhaps it's more understand if we say it's the power of the noise added?
Though the word power might mean different things for different people, so I didn't adopt this in this PR.

Signed-off-by: akarin <i@akarin.info>